### PR TITLE
Add restrictions for WebApi dependencies to allow using ContentDeliveryApi

### DIFF
--- a/EpiResponsivePicture/EpiResponsivePicture.csproj
+++ b/EpiResponsivePicture/EpiResponsivePicture.csproj
@@ -155,9 +155,8 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.6\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
@@ -203,13 +202,11 @@
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.Helpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Web.Http, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.7\lib\net45\System.Web.Http.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Web.Http, Version=5.2.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.6\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.WebHost, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.7\lib\net45\System.Web.Http.WebHost.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.6\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Mvc, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.7\lib\net45\System.Web.Mvc.dll</HintPath>

--- a/EpiResponsivePicture/packages.config
+++ b/EpiResponsivePicture/packages.config
@@ -14,10 +14,10 @@
   <package id="ImageResizer.WebConfig" version="4.0.1" targetFramework="net471" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net471" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net471" />
-  <package id="Microsoft.AspNet.WebApi" version="5.2.7" targetFramework="net471" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net471" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net471" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.7" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.6" allowedVersions="[5.2,5.2.7)" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.6" allowedVersions="[5.2,5.2.7)" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.6" allowedVersions="[5.2,5.2.7)" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.6" allowedVersions="[5.2,5.2.7)" targetFramework="net471" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net471" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net471" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net471" />


### PR DESCRIPTION
The newest version of the content delivery package requires webhost up to 5.2.6 .

- [ ] version should be lower or equal 5.2.6
- [ ] add restriction so that other developers do not update
- [x] prepare for a release (I think that no changes are required - like bumping version). The current version is 0.0.27620 but couldn't find anything in the source code with "27620".

![image](https://user-images.githubusercontent.com/14861637/93339200-92e53b00-f82b-11ea-835f-2e8b2e1923f0.png)

---

Issue:

![image](https://user-images.githubusercontent.com/14861637/93339262-a7293800-f82b-11ea-81ff-6de1337d9cba.png)
![image](https://user-images.githubusercontent.com/14861637/93339290-b01a0980-f82b-11ea-855c-550f73ad8ea9.png)

---

No breaking changes:

![image](https://user-images.githubusercontent.com/14861637/93339527-f96a5900-f82b-11ea-8261-d8628343ac9f.png)