### PR TITLE
Add option for rendering sources

### DIFF
--- a/EpiResponsivePicture/ResizedImage/ImageTransformationHelper.cs
+++ b/EpiResponsivePicture/ResizedImage/ImageTransformationHelper.cs
@@ -47,7 +47,27 @@ public static class ImageTransformationHelper
 
         return new HtmlString(writer.ToString());
     }
-        
+
+    public static HtmlString ResizedPictureSources(this IHtmlHelper helper,
+        ContentReference image,
+        PictureProfile profile,
+        string fallbackUrl = null,
+        ResizedPictureViewModel pictureModel = null)
+    {
+        var pictureTag = PictureTagBuilder
+            .Create()
+            .WithContentReference(image)
+            .WithProfile(profile)
+            .WithFallbackUrl(fallbackUrl)
+            .WithViewModel(pictureModel)
+            .Build();
+
+        using var writer = new StringWriter();
+        pictureTag.RenderBody()?.WriteTo(writer, HtmlEncoder.Default);
+
+        return new HtmlString(writer.ToString());
+    }
+    
     private static string ResolveImageUrl(ContentReference image)
     {
         var urlResolver = ServiceLocator.Current.GetInstance<IUrlResolver>();

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="EPiServer" value="http://nuget.episerver.com/feed/packages.svc/" />
+    <add key="EPiServer" value="https://nuget.episerver.com/feed/packages.svc/" />
   </packageSources>
 </configuration>

--- a/README.md
+++ b/README.md
@@ -140,6 +140,20 @@ This will render following markup:
     <img alt="" src="/globalassets/path-to-image.jpg?w=800">
 </picture>
 ```
+
+Should you ever find yourself in need of generating only body of picture tag (ie when creating tag in React) you should make use of
+```cs
+@Html.ResizedPictureSources(Model, PictureProfiles.SampleProfile)
+```
+
+Following will result in:
+```html
+<source media="(min-width:1900px)" sizes="90vw" srcset="/globalassets/path-to-image.jpg?w=1900 1900w, /globalassets/path-to-image.jpg?w=2400 2400w">
+<source media="(min-width:1000px)" sizes="(min-width: 1400px) 1400px, 100vw" srcset="/globalassets/path-to-image.jpg?mode=crop&w=1000&h=562&crop=0,511,1064,1109 1000w, /globalassets/path-to-image.jpg?mode=crop&w=1200&h=675&crop=0,511,1064,1109 1200w, /globalassets/path-to-image.jpg?mode=crop&w=1400&h=787&crop=0,511,1064,1109 1400w, /globalassets/path-to-image.jpg?mode=crop&w=1600&h=900&crop=0,511,1064,1109 1600w">
+<source media="(max-width:1000px)" sizes="(min-width: 1400px) 1400px, 100vw" srcset="/globalassets/path-to-image.jpg?mode=crop&quality=60&w=1000&h=1000&crop=0,278,1064,1342 1000w, /globalassets/path-to-image.jpg?mode=crop&quality=60&w=1200&h=1200&crop=0,278,1064,1342 1200w, /globalassets/path-to-image.jpg?mode=crop&quality=60&w=1400&h=1400&crop=0,278,1064,1342 1400w, /globalassets/path-to-image.jpg?mode=crop&quality=60&w=1600&h=1600&crop=0,278,1064,1342 1600w">
+<img alt="" src="/globalassets/path-to-image.jpg?w=800">
+```
+
 ## CSS Helpers
 To avoid writing media-queries as strings a couple of helper methods are provided in `CssHelpers`
 * `MediaQueryMaxWidth(100)` -> `"(max-width:100px)"`


### PR DESCRIPTION
Added support for creating picture tags in frontend. 

Example usage:
```
public static readonly PictureProfile SampleProfile = new PictureProfile
{
    DefaultWidth = 800,
    MaxImageDimension = 2500,
    Sources = new []
    {
        new PictureSource
        {
            MediaCondition = MediaQueryMinWidth(1900),
            AllowedWidths = new [] { 
                1900, 
                2400, 
            },
            Sizes = new [] 
            { 
                Size((90, Unit.Vw)), 
            },
        },
        new PictureSource
        {
            MediaCondition = MediaQueryMinWidth(1000),
            AllowedWidths = new [] 
            { 
                1000, 
                1200, 
                1400, 
                1600, 
            },
            Mode = ScaleMode.Crop,
            TargetAspectRatio = AspectRatio.Create(16,9),
            Sizes = new [] 
            { 
                MediaQueryMinWidthWithSize(1400, 1400), 
                Size((100, Unit.Vw)),
            },

        },
        new PictureSource
        {
            MediaCondition = MediaQueryMaxWidth(1000),
            AllowedWidths = new [] { 
                1000, 
                1200, 
                1400, 
                1600, 
            },
            Mode = ScaleMode.Crop,
            TargetAspectRatio = AspectRatio.Create(1),
            Quality = 60,
            Sizes = new [] { 
                Size((50, Unit.Vw)), 
            },
        }
    },
};

@Html.ResizedPictureSources(Model.CurrentPage.Image, PictureProfiles.SampleProfile);
```

Will result in:
`<source media="(min-width:1900px)" sizes="90vw" srcset="/globalassets/path-to-image.jpg?w=1900 1900w, /globalassets/path-to-image.jpg?w=2400 2400w">
    <source media="(min-width:1000px)" sizes="(min-width: 1400px) 1400px, 100vw" srcset="/globalassets/path-to-image.jpg?mode=crop&w=1000&h=562&crop=0,511,1064,1109 1000w, /globalassets/path-to-image.jpg?mode=crop&w=1200&h=675&crop=0,511,1064,1109 1200w, /globalassets/path-to-image.jpg?mode=crop&w=1400&h=787&crop=0,511,1064,1109 1400w, /globalassets/path-to-image.jpg?mode=crop&w=1600&h=900&crop=0,511,1064,1109 1600w">
    <source media="(max-width:1000px)" sizes="(min-width: 1400px) 1400px, 100vw" srcset="/globalassets/path-to-image.jpg?mode=crop&quality=60&w=1000&h=1000&crop=0,278,1064,1342 1000w, /globalassets/path-to-image.jpg?mode=crop&quality=60&w=1200&h=1200&crop=0,278,1064,1342 1200w, /globalassets/path-to-image.jpg?mode=crop&quality=60&w=1400&h=1400&crop=0,278,1064,1342 1400w, /globalassets/path-to-image.jpg?mode=crop&quality=60&w=1600&h=1600&crop=0,278,1064,1342 1600w">
    <img alt="" src="/globalassets/path-to-image.jpg?w=800">`