### PR TITLE
Bugfix/40 fallback image

### DIFF
--- a/EpiResponsivePicture/GeneratorProfiles/ImageSharpResizedUrlGenerator.cs
+++ b/EpiResponsivePicture/GeneratorProfiles/ImageSharpResizedUrlGenerator.cs
@@ -18,27 +18,27 @@ public sealed class ImageSharpResizedUrlGenerator : ResizedUrlGeneratorBase
     {
         RegisterCustomQuery(
             (width, pictureSource, _, _) => HeightQuery(width, pictureSource),
-            (_, pictureSource, _, _) => pictureSource.TargetAspectRatio != AspectRatio.Original
+            (_, pictureSource, _, _) => pictureSource != null && pictureSource.TargetAspectRatio != AspectRatio.Original
         );
         RegisterCustomQuery(
             (_, pictureSource, _, _) => QualityQuery(pictureSource),
-            (_, pictureSource, _, _) => pictureSource.Quality != PictureQuality.Default
+            (_, pictureSource, _, _) => pictureSource != null && pictureSource.Quality != PictureQuality.Default
         );
         RegisterCustomQuery((_, _, _, focalPoint) => FocalPointQuery(focalPoint));
         RegisterCustomQuery(
-            (_, pictureSource, _, _) => (Mode, $"{pictureSource.Mode.ToString()}"), 
-            (_, pictureSource, _, _) => pictureSource.Mode != ScaleMode.Default
+            (_, pictureSource, _, _) => (Mode, $"{pictureSource.Mode.ToString()}"),
+            (_, pictureSource, _, _) => pictureSource != null &&  pictureSource.Mode != ScaleMode.Default
             );
         RegisterCustomQuery(
-            (_, _, pictureProfile, _) => FormatQuery(pictureProfile), 
-            (_, _, pictureProfile, _) => pictureProfile.Format != ResizedImageFormat.Preserve
+            (_, _, pictureProfile, _) => FormatQuery(pictureProfile),
+            (_, _, pictureProfile, _) => pictureProfile != null && pictureProfile.Format != ResizedImageFormat.Preserve
             );
     }
-    
+
     protected override (string Key, string Value) WidthQuery(int width) => (Width, width.ToString());
-    private (string Key, string Value) FocalPointQuery(FocalPoint focalPoint) => 
+    private (string Key, string Value) FocalPointQuery(FocalPoint focalPoint) =>
         (FocalPoint, $"{focalPoint.X:0.###},{focalPoint.Y:0.###}");
-    private (string Key, string Value) HeightQuery(int width, PictureSource source) => 
+    private (string Key, string Value) HeightQuery(int width, PictureSource source) =>
         (Height, Math.Round(width / source.TargetAspectRatio.Ratio).ToString(CultureInfo.InvariantCulture));
     private (string Key, string Value) QualityQuery(PictureSource source) => (Quality, source.Quality.ToString());
     private (string Key, string Value) FormatQuery(PictureProfile profile) => (Format, profile.Format switch

--- a/EpiResponsivePicture/TagBuilders/PictureTagBuilder.cs
+++ b/EpiResponsivePicture/TagBuilders/PictureTagBuilder.cs
@@ -3,6 +3,7 @@ using EPiServer;
 using EPiServer.Core;
 using EPiServer.ServiceLocation;
 using EPiServer.Web.Routing;
+using Forte.EpiResponsivePicture.GeneratorProfiles;
 using Forte.EpiResponsivePicture.ResizedImage;
 using Forte.EpiResponsivePicture.ResizedImage.Property;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -13,6 +14,7 @@ namespace Forte.EpiResponsivePicture.TagBuilders;
 public class PictureTagBuilder : IPictureTagBuilder
 {
     private readonly TagBuilder element;
+    private readonly IResizedUrlGenerator resizedUrlGenerator;
     private PictureProfile pictureProfile;
     private ContentReference pictureContentReference;
     private string pictureFallbackUrl;
@@ -24,6 +26,7 @@ public class PictureTagBuilder : IPictureTagBuilder
     private PictureTagBuilder()
     {
         element = new TagBuilder("picture");
+        resizedUrlGenerator = ServiceLocator.Current.GetInstance<IResizedUrlGenerator>();
     }
 
     public static IPictureTagBuilder Create() => new PictureTagBuilder();
@@ -123,7 +126,11 @@ public class PictureTagBuilder : IPictureTagBuilder
     {
         var imgTagBuilder = new TagBuilder("img");
 
-        imgTagBuilder.Attributes.Add("src", pictureUrl);
+        var url = string.IsNullOrEmpty(pictureFallbackUrl)
+            ? resizedUrlGenerator.GenerateUrl(pictureUrl, pictureProfile.DefaultWidth, null, null, focalPoint).ToString()
+            : pictureFallbackUrl;
+
+        imgTagBuilder.Attributes.Add("src", url);
 
         foreach (var imgElementAttribute in pictureViewModel.ImgElementAttributes)
         {


### PR DESCRIPTION
Fix for #40 

After this fix a fallback `img` created within `picture` will indlude query parameters like default width or rxy