### PR TITLE
Allow to override default SourceTagBuilder and PictureTagBuilder classes

### DIFF
--- a/EpiResponsivePicture.Tests/PictureTagBuilderTests.cs
+++ b/EpiResponsivePicture.Tests/PictureTagBuilderTests.cs
@@ -60,12 +60,12 @@ public class PictureTagBuilderTests
     [Test]
     public void When_PictureProfile_Is_Null_Throw_ArgumentNullException()
     {
-        var pictureTagBuilder = PictureTagBuilder.Create().WithProfile(null);
+        var pictureTagBuilder = new PictureTagBuilder(resizedUrlGenerator.Object, new SourceTagBuilderProvider(resizedUrlGenerator.Object)).WithProfile(null);
 
         Assert.Throws<ArgumentNullException>(() => pictureTagBuilder.Build());
     }
 
-    [TestCase(ExpectedResult = "<picture><source media=\"(min-width: 1900px)\" sizes=\"90vw\" srcset=\"/images/foo.jpg?QUERIES 1900w, /images/foo.jpg?QUERIES 2400w\" /><source media=\"(min-width: 1000px)\" sizes=\"(min-width: 1400px) 1400px, 100vw\" srcset=\"/images/foo.jpg?QUERIES 1000w, /images/foo.jpg?QUERIES 1200w, /images/foo.jpg?QUERIES 1400w, /images/foo.jpg?QUERIES 1600w\" /><source media=\"(max-width: 1000px)\" sizes=\"50vw\" srcset=\"/images/foo.jpg?QUERIES 1000w, /images/foo.jpg?QUERIES 1200w, /images/foo.jpg?QUERIES 1400w, /images/foo.jpg?QUERIES 1600w\" /><img alt=\"\" src=\"/images/fallback.jpg\" /></picture>")]
+    [TestCase(ExpectedResult = "<picture><source media=\"(min-width: 1900px)\" sizes=\"90vw\" srcset=\"/images/foo.jpg?QUERIES 1900w, /images/foo.jpg?QUERIES 2400w\" /><source media=\"(min-width: 1000px)\" sizes=\"(min-width: 1400px) 1400px, 100vw\" srcset=\"/images/foo.jpg?QUERIES 1000w, /images/foo.jpg?QUERIES 1200w, /images/foo.jpg?QUERIES 1400w, /images/foo.jpg?QUERIES 1600w\" /><source media=\"(max-width: 1000px)\" sizes=\"50vw\" srcset=\"/images/foo.jpg?QUERIES 1000w, /images/foo.jpg?QUERIES 1200w, /images/foo.jpg?QUERIES 1400w, /images/foo.jpg?QUERIES 1600w\" /><img src=\"/images/fallback.jpg\" /></picture>")]
     public string Readme_Example_Should_Work()
     {
         var imageContentMock = new Mock<IContentData>().Object;
@@ -104,8 +104,7 @@ public class PictureTagBuilderTests
             },
         };
 
-        var pictureTagBuilder = PictureTagBuilder
-            .Create()
+        var pictureTagBuilder = new PictureTagBuilder(resizedUrlGenerator.Object, new SourceTagBuilderProvider(resizedUrlGenerator.Object))
             .WithProfile(profile)
             .WithContentReference(contentReferenceMock.Object)
             .WithFallbackUrl(FallbackUrl);
@@ -117,7 +116,7 @@ public class PictureTagBuilderTests
         return writer.ToString();
     }
 
-    [TestCase(ExpectedResult = "<picture><source media=\"(min-width: 1900px)\" sizes=\"90vw\" srcset=\"/images/foo.jpg?QUERIES 1900w, /images/foo.jpg?QUERIES 2400w\" /><img alt=\"\" src=\"/images/foo.jpg?QUERIES\" /></picture>")]
+    [TestCase(ExpectedResult = "<picture><source media=\"(min-width: 1900px)\" sizes=\"90vw\" srcset=\"/images/foo.jpg?QUERIES 1900w, /images/foo.jpg?QUERIES 2400w\" /><img src=\"/images/foo.jpg?QUERIES\" /></picture>")]
     public string Fallback_Img_Should_Include_Queries()
     {
         IContentData imageContentMock = new ImageBase();
@@ -138,8 +137,7 @@ public class PictureTagBuilderTests
             },
         };
 
-        var pictureTagBuilder = PictureTagBuilder
-            .Create()
+        var pictureTagBuilder = new PictureTagBuilder(resizedUrlGenerator.Object, new SourceTagBuilderProvider(resizedUrlGenerator.Object))
             .WithProfile(profile)
             .WithContentReference(contentReferenceMock.Object);
 
@@ -164,8 +162,7 @@ public class PictureTagBuilderTests
             },
         };
 
-        var pictureTagBuilder = PictureTagBuilder
-            .Create()
+        var pictureTagBuilder = new PictureTagBuilder(resizedUrlGenerator.Object, new SourceTagBuilderProvider(resizedUrlGenerator.Object))
             .WithProfile(profile)
             .WithContentReference(contentReferenceMock.Object)
             .WithFallbackUrl(FallbackUrl);
@@ -193,8 +190,7 @@ public class PictureTagBuilderTests
             },
         };
 
-        var pictureTagBuilder = PictureTagBuilder
-            .Create()
+        var pictureTagBuilder = new PictureTagBuilder(resizedUrlGenerator.Object, new SourceTagBuilderProvider(resizedUrlGenerator.Object))
             .WithProfile(profile)
             .WithContentReference(contentReferenceMock.Object)
             .WithFallbackUrl(FallbackUrl);
@@ -232,8 +228,7 @@ public class PictureTagBuilderTests
             },
         };
 
-        var pictureTagBuilder = PictureTagBuilder
-            .Create()
+        var pictureTagBuilder = new PictureTagBuilder(resizedUrlGenerator.Object, new SourceTagBuilderProvider(resizedUrlGenerator.Object))
             .WithProfile(profile)
             .WithContentReference(contentReferenceMock.Object)
             .WithFallbackUrl(FallbackUrl);
@@ -271,8 +266,7 @@ public class PictureTagBuilderTests
             },
         };
 
-        var pictureTagBuilder = PictureTagBuilder
-            .Create()
+        var pictureTagBuilder = new PictureTagBuilder(resizedUrlGenerator.Object, new SourceTagBuilderProvider(resizedUrlGenerator.Object))
             .WithProfile(profile)
             .WithContentReference(contentReferenceMock.Object)
             .WithFallbackUrl(FallbackUrl);

--- a/EpiResponsivePicture/Extensions/ServiceCollectionExtensions.cs
+++ b/EpiResponsivePicture/Extensions/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Forte.EpiResponsivePicture.Blob;
 using Forte.EpiResponsivePicture.Configuration;
 using Forte.EpiResponsivePicture.GeneratorProfiles;
 using Forte.EpiResponsivePicture.ResizedImage.Property.Compatibility.SqlProvider;
+using Forte.EpiResponsivePicture.TagBuilders;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using SixLabors.ImageSharp.Web.Caching.Azure;
@@ -27,7 +28,7 @@ public static class ServiceCollectionExtensions
     /// <param name="services">Services</param>
     /// <param name="options"></param>
     /// <returns>services</returns>
-    public static IServiceCollection AddForteEpiResponsivePicture(this IServiceCollection services, 
+    public static IServiceCollection AddForteEpiResponsivePicture(this IServiceCollection services,
         EpiResponsivePicturesOptions options = null)
     {
         services.AddImageSharp()
@@ -35,9 +36,9 @@ public static class ServiceCollectionExtensions
             .AddProvider<BlobImageProvider>()
             .AddProvider<PhysicalFileSystemProvider>()
             .SetCache<BlobImageCache>();
-            
+
         ConfigureModule(services, options);
-                   
+
         return services;
     }
 
@@ -49,9 +50,9 @@ public static class ServiceCollectionExtensions
     /// <param name="options"></param>
     /// <returns>services</returns>
     public static IServiceCollection AddForteEpiResponsivePicture(this IServiceCollection services,
-        Action<AzureBlobStorageCacheOptions> azureStorageOptions, 
+        Action<AzureBlobStorageCacheOptions> azureStorageOptions,
         EpiResponsivePicturesOptions options = null)
-    {   
+    {
         azureStorageOptions += ValidateOptions;
         azureStorageOptions += CreateContainerIfNotExists;
         services.AddImageSharp()
@@ -59,12 +60,12 @@ public static class ServiceCollectionExtensions
             .ClearProviders()
             .AddProvider<BlobImageProvider>()
             .SetCache<AzureBlobStorageCache>();
-            
+
         ConfigureModule(services, options);
 
         return services;
     }
-    
+
     /// <summary>
     /// Creates container with provided name, when it does not exist
     /// </summary>
@@ -73,7 +74,7 @@ public static class ServiceCollectionExtensions
     {
         AzureBlobStorageCache.CreateIfNotExists(options, PublicAccessType.None);
     }
-    
+
     /// <summary>
     /// Checks if necessary options were provided, otherwise throws exception
     /// </summary>
@@ -94,7 +95,7 @@ public static class ServiceCollectionExtensions
     private static void ConfigureModule(IServiceCollection services, EpiResponsivePicturesOptions options = null)
     {
         services.TryAddTransient<IResizedUrlGenerator, ImageSharpResizedUrlGenerator>();
-            
+
         services.Configure<ProtectedModuleOptions>(o =>
         {
             if (!o.Items.Any(x => x.Name.Equals(Constants.ModuleName)))
@@ -116,7 +117,8 @@ public static class ServiceCollectionExtensions
             });
 
         services.AddSingleton<IBlobSegmentsProvider, BlobCustomSegmentsProvider>();
-        services
-            .AddTransient<IImageResizerFocalPointConversionSqlProvider, ImageResizerFocalPointConversionSqlProvider>();
+        services.AddTransient<IImageResizerFocalPointConversionSqlProvider, ImageResizerFocalPointConversionSqlProvider>();
+        services.AddTransient<IPictureTagBuilderProvider, PictureTagBuilderProvider>();
+        services.AddTransient<ISourceTagBuilderProvider, SourceTagBuilderProvider>();
     }
 }

--- a/EpiResponsivePicture/ResizedImage/ImageTransformationHelper.cs
+++ b/EpiResponsivePicture/ResizedImage/ImageTransformationHelper.cs
@@ -16,11 +16,11 @@ public static class ImageTransformationHelper
         ResizedImageFormat format = ResizedImageFormat.Preserve)
     {
         var baseUrl = ResolveImageUrl(image);
-                
+
         var urlBuilder = new UrlBuilder(baseUrl)
             .Add("width", width.ToString());
-                
-        if(format != ResizedImageFormat.Preserve) 
+
+        if(format != ResizedImageFormat.Preserve)
             urlBuilder.Add("format", format.ToString().ToUpperInvariant());
 
         return urlBuilder;
@@ -33,8 +33,9 @@ public static class ImageTransformationHelper
         ResizedPictureViewModel pictureModel = null)
     {
 
-        var pictureTag = PictureTagBuilder
-            .Create()
+        var pictureTagBuilderProvider = ServiceLocator.Current.GetInstance<IPictureTagBuilderProvider>();
+
+        var pictureTag = pictureTagBuilderProvider.Create()
             .WithContentReference(image)
             .WithProfile(profile)
             .WithFallbackUrl(fallbackUrl)
@@ -42,7 +43,7 @@ public static class ImageTransformationHelper
             .Build();
 
         using var writer = new StringWriter();
-            
+
         pictureTag.WriteTo(writer, HtmlEncoder.Default);
 
         return new HtmlString(writer.ToString());
@@ -54,8 +55,9 @@ public static class ImageTransformationHelper
         string fallbackUrl = null,
         ResizedPictureViewModel pictureModel = null)
     {
-        var pictureTag = PictureTagBuilder
-            .Create()
+        var pictureTagBuilderProvider = ServiceLocator.Current.GetInstance<IPictureTagBuilderProvider>();
+
+        var pictureTag = pictureTagBuilderProvider.Create()
             .WithContentReference(image)
             .WithProfile(profile)
             .WithFallbackUrl(fallbackUrl)
@@ -67,7 +69,7 @@ public static class ImageTransformationHelper
 
         return new HtmlString(writer.ToString());
     }
-    
+
     private static string ResolveImageUrl(ContentReference image)
     {
         var urlResolver = ServiceLocator.Current.GetInstance<IUrlResolver>();

--- a/EpiResponsivePicture/TagBuilders/IPictureTagBuilderProvider.cs
+++ b/EpiResponsivePicture/TagBuilders/IPictureTagBuilderProvider.cs
@@ -1,0 +1,6 @@
+namespace Forte.EpiResponsivePicture.TagBuilders;
+
+public interface IPictureTagBuilderProvider
+{
+    IPictureTagBuilder Create();
+}

--- a/EpiResponsivePicture/TagBuilders/ISourceTagBuilderProvider.cs
+++ b/EpiResponsivePicture/TagBuilders/ISourceTagBuilderProvider.cs
@@ -1,0 +1,6 @@
+namespace Forte.EpiResponsivePicture.TagBuilders;
+
+public interface ISourceTagBuilderProvider
+{
+    ISourceTagBuilder Create();
+}

--- a/EpiResponsivePicture/TagBuilders/PictureTagBuilder.cs
+++ b/EpiResponsivePicture/TagBuilders/PictureTagBuilder.cs
@@ -14,63 +14,63 @@ namespace Forte.EpiResponsivePicture.TagBuilders;
 public class PictureTagBuilder : IPictureTagBuilder
 {
     private readonly TagBuilder element;
-    private readonly IResizedUrlGenerator resizedUrlGenerator;
-    private PictureProfile pictureProfile;
-    private ContentReference pictureContentReference;
-    private string pictureFallbackUrl;
-    private ResizedPictureViewModel pictureViewModel;
-    private FocalPoint focalPoint;
-    private string pictureUrl;
-    private string imgTagAltText;
+    protected readonly IResizedUrlGenerator ResizedUrlGenerator;
+    protected readonly ISourceTagBuilderProvider SourceTagBuilderProvider;
+    protected PictureProfile PictureProfile;
+    protected ContentReference PictureContentReference;
+    protected string PictureFallbackUrl;
+    protected ResizedPictureViewModel PictureViewModel;
+    protected FocalPoint FocalPoint;
+    protected string PictureUrl;
+    protected string ImgTagAltText;
 
-    private PictureTagBuilder()
+    public PictureTagBuilder(IResizedUrlGenerator resizedUrlGenerator, ISourceTagBuilderProvider sourceTagBuilderProvider)
     {
         element = new TagBuilder("picture");
-        resizedUrlGenerator = ServiceLocator.Current.GetInstance<IResizedUrlGenerator>();
+        ResizedUrlGenerator = resizedUrlGenerator;
+        SourceTagBuilderProvider = sourceTagBuilderProvider;
     }
-
-    public static IPictureTagBuilder Create() => new PictureTagBuilder();
 
     public IPictureTagBuilder WithProfile(PictureProfile profile)
     {
-        pictureProfile = profile;
+        PictureProfile = profile;
         return this;
     }
 
     public IPictureTagBuilder WithContentReference(ContentReference contentReference)
     {
-        pictureContentReference = contentReference;
+        PictureContentReference = contentReference;
         return this;
     }
 
     public IPictureTagBuilder WithFallbackUrl(string fallbackUrl)
     {
-        pictureFallbackUrl = fallbackUrl;
+        PictureFallbackUrl = fallbackUrl;
         return this;
     }
 
     public IPictureTagBuilder WithViewModel(ResizedPictureViewModel viewModel)
     {
-        pictureViewModel = viewModel;
+        PictureViewModel = viewModel;
         return this;
     }
 
     public TagBuilder Build()
     {
-        Guard.IsNotNull(pictureProfile, nameof(pictureProfile));
+        Guard.IsNotNull(PictureProfile, nameof(PictureProfile));
 
-        pictureFallbackUrl ??= string.Empty;
-        pictureViewModel ??= new ResizedPictureViewModel();
+        PictureFallbackUrl ??= string.Empty;
+        PictureViewModel ??= new ResizedPictureViewModel();
 
         SetPictureData();
 
-        var sourceTagBuilder = SourceTagBuilder
+        var sourceTagBuilder = SourceTagBuilderProvider
             .Create()
-            .WithImageUrl(pictureUrl)
-            .WithFocalPoint(focalPoint)
-            .WithProfile(pictureProfile);
+            .WithImageUrl(PictureUrl)
+            .WithFocalPoint(FocalPoint)
+            .WithProfile(PictureProfile);
 
-        foreach (var pictureSource in pictureProfile.Sources)
+        foreach (var pictureSource in PictureProfile.Sources)
         {
             var sourceTag = sourceTagBuilder.NewTag().WithSource(pictureSource).Build();
 
@@ -88,7 +88,7 @@ public class PictureTagBuilder : IPictureTagBuilder
     private void SetPictureData()
     {
         var imageFound = ServiceLocator.Current.GetInstance<IContentLoader>().TryGet<IContentData>(
-            pictureContentReference,
+            PictureContentReference,
             new LoaderOptions { LanguageLoaderOption.FallbackWithMaster() }, out var content);
 
         if (imageFound)
@@ -103,28 +103,28 @@ public class PictureTagBuilder : IPictureTagBuilder
             }
         }
 
-        pictureUrl = imageFound ? ResolveUrl() : pictureFallbackUrl;
+        PictureUrl = imageFound ? ResolveUrl() : PictureFallbackUrl;
     }
 
     private void SetImageAltText(IImage image)
     {
-        imgTagAltText = image.Description ?? string.Empty;
+        ImgTagAltText = image.Description ?? string.Empty;
     }
 
     private void SetFocalPoint(IResponsiveImage responsiveImage)
     {
-        focalPoint = responsiveImage.FocalPoint ?? FocalPoint.Center;
+        FocalPoint = responsiveImage.FocalPoint ?? FocalPoint.Center;
     }
 
     private string ResolveUrl()
     {
         var urlResolver = ServiceLocator.Current.GetInstance<IUrlResolver>();
-        return urlResolver.GetUrl(pictureContentReference);
+        return urlResolver.GetUrl(PictureContentReference);
     }
 
     private void AddAdditionalAttributes()
     {
-        foreach (var (key, value) in pictureViewModel.PictureElementAttributes)
+        foreach (var (key, value) in PictureViewModel.PictureElementAttributes)
         {
             element.Attributes.Add(key, value);
         }
@@ -134,20 +134,20 @@ public class PictureTagBuilder : IPictureTagBuilder
     {
         var imgTagBuilder = new TagBuilder("img");
 
-        var url = string.IsNullOrEmpty(pictureFallbackUrl)
-            ? resizedUrlGenerator.GenerateUrl(pictureUrl, pictureProfile.DefaultWidth, null, pictureProfile, focalPoint).ToString()
-            : pictureFallbackUrl;
+        var url = string.IsNullOrEmpty(PictureFallbackUrl)
+            ? ResizedUrlGenerator.GenerateUrl(PictureUrl, PictureProfile.DefaultWidth, null, PictureProfile, FocalPoint).ToString()
+            : PictureFallbackUrl;
 
         imgTagBuilder.Attributes.Add("src", url);
 
-        foreach (var imgElementAttribute in pictureViewModel.ImgElementAttributes)
+        foreach (var imgElementAttribute in PictureViewModel.ImgElementAttributes)
         {
             imgTagBuilder.Attributes.Add(imgElementAttribute);
         }
 
-        if (!string.IsNullOrEmpty(imgTagAltText))
+        if (!string.IsNullOrEmpty(ImgTagAltText))
         {
-            imgTagBuilder.Attributes.TryAdd("alt", imgTagAltText);
+            imgTagBuilder.Attributes.TryAdd("alt", ImgTagAltText);
         }
 
         return imgTagBuilder;

--- a/EpiResponsivePicture/TagBuilders/PictureTagBuilderProvider.cs
+++ b/EpiResponsivePicture/TagBuilders/PictureTagBuilderProvider.cs
@@ -1,0 +1,17 @@
+using Forte.EpiResponsivePicture.GeneratorProfiles;
+
+namespace Forte.EpiResponsivePicture.TagBuilders;
+
+public class PictureTagBuilderProvider : IPictureTagBuilderProvider
+{
+    private readonly IResizedUrlGenerator resizedUrlGenerator;
+    private readonly ISourceTagBuilderProvider sourceTagBuilderProvider;
+
+    public PictureTagBuilderProvider(IResizedUrlGenerator resizedUrlGenerator, ISourceTagBuilderProvider sourceTagBuilderProvider)
+    {
+        this.resizedUrlGenerator = resizedUrlGenerator;
+        this.sourceTagBuilderProvider = sourceTagBuilderProvider;
+    }
+
+    public IPictureTagBuilder Create() => new PictureTagBuilder(resizedUrlGenerator, sourceTagBuilderProvider);
+}

--- a/EpiResponsivePicture/TagBuilders/SourceTagBuilderProvider.cs
+++ b/EpiResponsivePicture/TagBuilders/SourceTagBuilderProvider.cs
@@ -1,0 +1,15 @@
+using Forte.EpiResponsivePicture.GeneratorProfiles;
+
+namespace Forte.EpiResponsivePicture.TagBuilders;
+
+public class SourceTagBuilderProvider : ISourceTagBuilderProvider
+{
+    private readonly IResizedUrlGenerator resizedUrlGenerator;
+
+    public SourceTagBuilderProvider(IResizedUrlGenerator resizedUrlGenerator)
+    {
+        this.resizedUrlGenerator = resizedUrlGenerator;
+    }
+
+    public ISourceTagBuilder Create() => new SourceTagBuilder(resizedUrlGenerator);
+}

--- a/README.md
+++ b/README.md
@@ -202,6 +202,10 @@ builder.Services.AddTransient<YourCustomUrlGenerator>();
 builder.Services.AddForteEpiResponsivePicture();
 ```
 
+## Custom ISourceTagBuilder and IPictureTagBuilder
+
+If you want to have custom logic of creating `<picture>` or `<source>` elements you can register your own implementations of `ISourceTagBuilderProvider` and/or `IPictureTagBuilderProvider` which can produce your own builders. 
+
 ## Backwards compatibility
 ### ImageResizer
 


### PR DESCRIPTION
New interfaces are introduced:

```
public interface ISourceTagBuilderProvider
{
    ISourceTagBuilder Create();
}
```

and 

```
public interface IPictureTagBuilderProvider
{
    IPictureTagBuilder Create();
}
```

Default implementations of these interfaces are registered in DI container but user can override it in their own project which allows to have custom logic when it comes to building Picture and Source tags.