### PR TITLE
Enable config and usage for local filesystem config

### DIFF
--- a/EpiResponsivePicture/Extensions/ApplicationBuilderExtensions.cs
+++ b/EpiResponsivePicture/Extensions/ApplicationBuilderExtensions.cs
@@ -1,4 +1,3 @@
-using Baaijte.Optimizely.ImageSharp.Web.Providers;
 using Forte.EpiResponsivePicture.Blob;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,18 +15,19 @@ public static class ApplicationBuilderExtensions
     /// <summary>
     /// Adds ImageSharp. Fluent API
     /// </summary>
+    /// <param name="T">Specific type implementing IImageProvider</param>
     /// <param name="app"></param>
     /// <param name="providerRegistration"></param>
-    public static IApplicationBuilder UseForteEpiResponsivePicture(this IApplicationBuilder app,
-        Func<IApplicationBuilder, IApplicationBuilder> providerRegistration = null)
+    public static IApplicationBuilder UseForteEpiResponsivePicture<T>(this IApplicationBuilder app,
+        Func<IApplicationBuilder, IApplicationBuilder> providerRegistration = null) where T : IImageProvider
     {
         providerRegistration ??= SixLabors.ImageSharp.Web.DependencyInjection.ApplicationBuilderExtensions.UseImageSharp;
         providerRegistration(app);
 
         var imageProvider = app.ApplicationServices.GetServices<IImageProvider>()
-            .FirstOrDefault(instance => instance.GetType() == typeof(BlobImageProvider));
+            .FirstOrDefault(instance => instance is T);
         _ = imageProvider ?? throw new InvalidOperationException(
-            "BlobImageProvider is not found. Please make sure that it's added to ImageSharp service.");
+            $"{typeof(T).Name} is not found. Please make sure that it's added to ImageSharp service.");
         imageProvider.Match = app.ApplicationServices.GetService<IBlobSegmentsProvider>().IsMatch;
 
         return app;

--- a/EpiResponsivePicture/Extensions/ApplicationBuilderExtensions.cs
+++ b/EpiResponsivePicture/Extensions/ApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Baaijte.Optimizely.ImageSharp.Web.Providers;
 using Forte.EpiResponsivePicture.Blob;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,6 +13,17 @@ namespace Forte.EpiResponsivePicture.Extensions;
 
 public static class ApplicationBuilderExtensions
 {
+    /// <summary>
+    /// Adds ImageSharp. Fluent API
+    /// </summary>
+    /// <param name="app"></param>
+    /// <param name="providerRegistration"></param>
+    public static IApplicationBuilder UseForteEpiResponsivePicture(this IApplicationBuilder app,
+        Func<IApplicationBuilder, IApplicationBuilder> providerRegistration = null)
+    {
+        return app.UseForteEpiResponsivePicture<BlobImageProvider>(providerRegistration);
+    }
+
     /// <summary>
     /// Adds ImageSharp. Fluent API
     /// </summary>

--- a/EpiResponsivePicture/Extensions/ServiceCollectionExtensions.cs
+++ b/EpiResponsivePicture/Extensions/ServiceCollectionExtensions.cs
@@ -31,24 +31,28 @@ public static class ServiceCollectionExtensions
     /// Register services for FocalPoint, resizing with local caching. Fluent API
     /// </summary>
     /// <param name="services">Services</param>
-    /// <param name="options"></param>
+    /// <param name="epiResponsivePicturesOptions"></param>
+    /// <param name="physicalFileSystemProviderOptions">Options to configure physical file system provider</param>
     /// <returns>services</returns>
     public static IServiceCollection AddForteEpiResponsivePicture(this IServiceCollection services,
-        EpiResponsivePicturesOptions options = null)
+        EpiResponsivePicturesOptions epiResponsivePicturesOptions = null,
+        PhysicalFileSystemProviderOptions physicalFileSystemProviderOptions = null)
     {
         services
             .AddImageSharp(builder =>
             {
-                builder.OnParseCommandsAsync = CreateOnParseCommandsAsync(options);
+                builder.OnParseCommandsAsync = CreateOnParseCommandsAsync(epiResponsivePicturesOptions);
             })
             .ClearProviders()
             .RemoveProcessor<ResizeWebProcessor>()
             .AddProcessor(_ => new ResizeWebDownscaleProcessor(new ResizeWebProcessor()))
             .AddProvider<BlobImageProvider>()
+            .Configure<PhysicalFileSystemProviderOptions>(o =>
+                o = physicalFileSystemProviderOptions)
             .AddProvider<PhysicalFileSystemProvider>()
             .SetCache<BlobImageCache>();
 
-        ConfigureModule(services, options);
+        ConfigureModule(services, epiResponsivePicturesOptions);
 
         return services;
     }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ builder.Services.AddForteEpiResponsivePicture();
 
 var app = builder.Build();
 
-app.UseForteEpiResponsivePicture();
+app.UseForteEpiResponsivePicture<BlobImageProvider>(); // blob image provider selected for DXP deployment
 
 // Removed for brevity
 
@@ -46,7 +46,7 @@ public class Startup
             app.UseDeveloperExceptionPage();
         }
 
-        app.UseForteEpiResponsivePicture();
+        app.UseForteEpiResponsivePicture<BlobImageProvider>(); // blob image provider selected for DXP deployment
         
         // Removed for brevity
     }


### PR DESCRIPTION
Problem:
- for local development setup when images are stored in App_Data there are missing config capabilities for nuget packages:
    - UseForte.... is bound to use only blob provider
    - AddForte... gives no possibility to config physical file system provider
    
PR addresses these two issues